### PR TITLE
Workflow develop with Artifacts

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -19,3 +19,10 @@ jobs:
 
       - name: Makefile + Dockerfile docker build
         run: make build
+
+      # https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#passing-data-between-jobs-in-a-workflow
+      - name: Upload Built Binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: Distribution Binaries
+          path: dist

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -20,6 +20,10 @@ jobs:
       - name: Makefile + Dockerfile docker build
         run: make build
 
+      # Produces the binaries at the directory ./dist
+      - name: Makefile + Dockerfile docker dist
+        run: make dist
+
       # https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#passing-data-between-jobs-in-a-workflow
       - name: Upload Built Binaries
         uses: actions/upload-artifact@v2

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build CLI Binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -25,8 +25,20 @@ jobs:
         run: make dist
 
       # https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#passing-data-between-jobs-in-a-workflow
-      - name: Upload Built Binaries
+      - name: Upload MacOS Binary
         uses: actions/upload-artifact@v2
         with:
-          name: Distribution Binaries
-          path: dist
+          name: cloner-darwin-amd64
+          path: dist/cloner-darwin-amd64
+
+      - name: Upload Linux Binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: cloner-linux-amd64
+          path: dist/cloner-linux-amd64
+
+      - name: Upload Windows Binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: cloner-windows-amd64.exe
+          path: dist/cloner-windows-amd64.exe

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -14,14 +14,14 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Makefile local golang build
+      - name: Golang build
         run: make local
 
-      - name: Makefile + Dockerfile docker build
+      - name: Dockerized Cross-compile Build
         run: make build
 
       # Produces the binaries at the directory ./dist
-      - name: Makefile + Dockerfile docker dist
+      - name: Dockerized Binary Distribution
         run: make dist
 
       # https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#passing-data-between-jobs-in-a-workflow
@@ -42,3 +42,43 @@ jobs:
         with:
           name: cloner-windows-amd64.exe
           path: dist/cloner-windows-amd64.exe
+
+  # https://github.com/nightlark/ninja/blob/f1a33131154ae7d9648aa82afac462859535fb62/.github/workflows/release-ninja-binaries.yml#L8-L34
+  verify:
+    name: Verify CLI Binaries
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            bin_name: cloner-linux-amd64
+          - os: macOS-latest
+            bin_name: cloner-darwin-amd64
+          - os: windows-latest
+            bin_name: cloner-windows-amd64.exe
+    steps:
+      - name: Download math result for job 1
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.bin_name }}
+
+      # Install OS specific dependencies
+      - name: Unix Binary Validation
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+        env:
+          BIN_NAME: ${{ matrix.bin_name }}
+        run: |
+          ls -la ./${BIN_NAME}
+          chmod +x ./${BIN_NAME}
+          ./${BIN_NAME}
+
+      - name: Install Windows dependencies
+        if: matrix.os == 'windows-latest'
+        env:
+          BIN_NAME: ${{ matrix.bin_name }}
+        run: |
+          dir
+          echo $pwd\$env:BIN_NAME
+          start-process -nonewwindow $pwd\$env:BIN_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 1
+          # https://github.com/actions/checkout/pull/258 needs to fetch all tags
+          fetch-depth: 0
 
       - name: Makefile + Dockerfile dockerized release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Makes a Github Release
+    name: Github Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ build: clean ## Builds the docker image with binaries
 
 dist: build ## Makes the dir ./dist with binaries from docker image
 	@echo "Distribution libraries for version $(BIN_VERSION)"
-	docker run --rm -ti --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-darwin-amd64 /bins"
-	docker run --rm -ti --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-linux-amd64 /bins"
-	docker run --rm -ti --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-windows-amd64.exe /bins"
+	docker run --rm --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-darwin-amd64 /bins"
+	docker run --rm --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-linux-amd64 /bins"
+	docker run --rm --entrypoint sh -v $(PWD)/$(DIST_DIR):/bins $(ORG)/$(APP_NAME):$(BIN_VERSION) -c "cp /bin/$(APP_NAME)-windows-amd64.exe /bins"
 	ls -la $(PWD)/$(DIST_DIR)
 
 release: dist ## Publishes the built binaries in Github Releases


### PR DESCRIPTION
# Binaries

* The distribution binaries will be available in the actions 
  * https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#passing-data-between-jobs-in-a-workflow

* Testing each binary using the action verify
  * https://github.com/nightlark/ninja/blob/f1a33131154ae7d9648aa82afac462859535fb62/.github/workflows/release-ninja-binaries.yml#L8-L34
  * https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

# Actions Example

* Example of the binaries https://github.com/marcellodesales/cloner/actions/runs/243734515

# Merge Result

* Binaries will be published in the Github release