### PR TITLE
Generic test strategy for CLI tests

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -8,6 +8,17 @@ on:
       - feature/**
 
 jobs:
+  test:
+    name: Run Test Cases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Golang test
+        run: make test
+
   build:
     name: Build CLI Binaries
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,12 @@ clean: ## Deletes the directory ./build
 	rm -rf $(DIST_DIR)
 	mkdir $(DIST_DIR)
 
+test: ## Run the test cases
+	@echo "Testing current version $(BIN_VERSION)"
+	go test -v ./...
+
 local: clean ## Makes a local build using Go
+	@echo "Building binary locally $(BIN_VERSION)"
 	GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -o dist/cloner-darwin-local main.go
 
 build: clean ## Builds the docker image with binaries

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -17,8 +17,6 @@ package cmd
 
 import (
 	"testing"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 /**
@@ -27,37 +25,51 @@ import (
  */
 func TestGitCloneWithWrongURLs(t *testing.T) {
 
-	// https://github.com/smartystreets/goconvey/wiki#your-first-goconvey-test
-	// Only pass t into top-level Convey calls
-	Convey("Given an empty URL to clone", t, func() {
-		url := ""
-		forceClone := false
-		exitCode, errors := executeGitClone(url, forceClone)
+	wrongUrlTests := []CliTests{
+		{
+			title:              "Given an empty URL to clone",
+			input:              TestInput{url: "", forceClone: false},
+			exitCode:           1,
+			exactErrorMessages: map[string]bool{"git URL invalid: you must provide the repo URL": true},
+		},
+		{
+			title:                "Given an invalid git URL to clone",
+			input:                TestInput{url: "incorrect-url", forceClone: false},
+			exitCode:             1,
+			errorMessageContains: []string{"git URL invalid:", "did not find any match", "incorrect-url"},
+		},
+	}
 
-		Convey("The exit code should be 1", func() {
-			So(exitCode, ShouldEqual, 1)
-		})
-		Convey("With 1 error message", func() {
-			So(len(errors), ShouldEqual, 1)
-			So(errors[0].Error(), ShouldEqual, "git URL invalid: you must provide the repo URL")
-		})
-	})
+	// Execute the test cases
+	ExecuteCliTestsStrategy(t, wrongUrlTests)
+}
 
-	// https://github.com/smartystreets/goconvey/wiki#your-first-goconvey-test
-	// Only pass t into top-level Convey calls
-	Convey("Given an invalid git URL to clone", t, func() {
-		url := "abc-not-url"
-		forceClone := false
-		exitCode, errors := executeGitClone(url, forceClone)
+func TestGitCloneSuccessfullyForcing(t *testing.T) {
+	existingDirTests := []CliTests{
+		{
+			title: "Given existing cloned repo",
+			input: TestInput{
+				url:        "https://github.com/comsysto/redis-locks-with-grafana",
+				forceClone: true},
+			exitCode: 0,
+		},
+	}
 
-		Convey("The exit code should be 1", func() {
-			So(exitCode, ShouldEqual, 1)
-		})
-		Convey("With 1 error message", func() {
-			So(len(errors), ShouldEqual, 1)
-			So(errors[0].Error(), ShouldContainSubstring, "git URL invalid:")
-			So(errors[0].Error(), ShouldContainSubstring, url)
-		})
-	})
+	// Execute the test cases
+	ExecuteCliTestsStrategy(t, existingDirTests)
+}
 
+func TestGitCloneExistingDirs(t *testing.T) {
+
+	existingDirTests := []CliTests{
+		{
+			title:                "Given existing cloned repo",
+			input:                TestInput{url: "https://github.com/comsysto/redis-locks-with-grafana", forceClone: false},
+			exitCode:             2,
+			errorMessageContains: []string{"can't clone repo: clone location", "exists and it's not empty"},
+		},
+	}
+
+	// Execute the test cases
+	ExecuteCliTestsStrategy(t, existingDirTests)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,12 +16,14 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/marcellodesales/cloner/config"
 	"github.com/marcellodesales/cloner/util"
 	"github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 /**
@@ -43,5 +45,59 @@ func setup() {
 
 	if err := util.SetUpLogs(os.Stdout, logrus.InfoLevel.String()); err != nil {
 		os.Exit(1)
+	}
+}
+
+// the current CLI input to be tested
+type TestInput struct {
+	url        string
+	forceClone bool
+}
+
+type CliTests struct {
+	title                string
+	input                TestInput
+	exitCode             int
+	exactErrorMessages   map[string]bool // https://yourbasic.org/golang/implement-set/
+	errorMessageContains []string
+}
+
+/**
+ * Execute the CLI tests using our strategy
+ */
+func ExecuteCliTestsStrategy(t *testing.T, cliTests []CliTests) {
+	for _, tst := range cliTests {
+		t.Run(tst.title, func(t *testing.T) {
+			// https://github.com/smartystreets/goconvey/wiki#your-first-goconvey-test
+			// Only pass t into top-level Convey calls
+			Convey(tst.title, t, func() {
+
+				// Actual clone command to be tested
+				exitCode, errors := executeGitClone(tst.input.url, tst.input.forceClone)
+
+				Convey(fmt.Sprintf("The exit code should be %d", tst.exitCode), func() {
+					So(exitCode, ShouldEqual, tst.exitCode)
+				})
+
+				// Test exact error message cases
+				if len(tst.exactErrorMessages) > 0 {
+					Convey(fmt.Sprintf("With %d error message", len(tst.exactErrorMessages)), func() {
+						So(len(errors), ShouldEqual, len(tst.exactErrorMessages))
+						for _, errorMsg := range errors {
+							So(tst.exactErrorMessages[errorMsg.Error()], ShouldBeTrue)
+						}
+					})
+				}
+
+				// Test whether the error message contains strings
+				if len(tst.errorMessageContains) > 0 {
+					Convey(fmt.Sprintf("With %d error message", len(tst.errorMessageContains)), func() {
+						for _, errorMessageToken := range tst.errorMessageContains {
+							So(errors[0].Error(), ShouldContainSubstring, errorMessageToken)
+						}
+					})
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
* Implementing a test strategy for all tests, following the design of https://github.com/elwinar/rambler/blob/master/apply_test.go.
* All tests can reuse the same, testing the API inteface itself.
  * Function `ExecuteCliTestsStrategy` is located at the TestMain file `root_test.go`

# Design

* Use a template method for the strategy and placed it under TestMain
* Defined the interface for the tests to use as input

```go
	existingDirTests := []CliTests{
		{
			title: "Given existing cloned repo",
			input: TestInput{
				url:        "https://github.com/comsysto/redis-locks-with-grafana",
				forceClone: true},
			exitCode: 0,
		},
	}
```

* Testing the contract now is as simple as the following call

```go
ExecuteCliTestsStrategy(t, existingDirTests)
```

# Execution

```console
$ go test -v ./...
?   	github.com/marcellodesales/cloner	[no test files]
?   	github.com/marcellodesales/cloner/api/git	[no test files]
time="2020-09-12T00:59:12-03:00" level=info msg="Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'"
=== RUN   TestGitCloneWithWrongURLs
=== RUN   TestGitCloneWithWrongURLs/Given_an_empty_URL_to_clone

  Given an empty URL to clone
    The exit code should be 1 ✔
    With 1 error message ✔✔


3 total assertions

=== RUN   TestGitCloneWithWrongURLs/Given_an_invalid_git_URL_to_clone

  Given an invalid git URL to clone
    The exit code should be 1 ✔
    With 3 error message ✔✔✔


7 total assertions

--- PASS: TestGitCloneWithWrongURLs (0.00s)
    --- PASS: TestGitCloneWithWrongURLs/Given_an_empty_URL_to_clone (0.00s)
    --- PASS: TestGitCloneWithWrongURLs/Given_an_invalid_git_URL_to_clone (0.00s)
=== RUN   TestGitCloneSuccessfullyForcing
=== RUN   TestGitCloneSuccessfullyForcing/Given_existing_cloned_repo

  Given existing cloned repo time="2020-09-12T00:59:12-03:00" level=info msg="Forcing clone..."
time="2020-09-12T00:59:12-03:00" level=info msg="Deleted dir '/Users/marcellodesales/dev/github.com/comsysto/redis-locks-with-grafana'"
time="2020-09-12T00:59:12-03:00" level=info msg="Cloning into '/Users/marcellodesales/dev/github.com/comsysto/redis-locks-with-grafana'"
Enumerating objects: 233, done.
Total 233 (delta 0), reused 0 (delta 0), pack-reused 233
time="2020-09-12T00:59:14-03:00" level=info msg=Done...

    The exit code should be 0 ✔


8 total assertions

--- PASS: TestGitCloneSuccessfullyForcing (2.74s)
    --- PASS: TestGitCloneSuccessfullyForcing/Given_existing_cloned_repo (2.74s)
=== RUN   TestGitCloneExistingDirs
=== RUN   TestGitCloneExistingDirs/Given_existing_cloned_repo

  Given existing cloned repo
    The exit code should be 2 ✔
    With 2 error message ✔✔


11 total assertions

--- PASS: TestGitCloneExistingDirs (0.00s)
    --- PASS: TestGitCloneExistingDirs/Given_existing_cloned_repo (0.00s)
PASS
ok  	github.com/marcellodesales/cloner/cmd	(cached)
?   	github.com/marcellodesales/cloner/config	[no test files]
?   	github.com/marcellodesales/cloner/util	[no test files]
```