### PR TITLE
Bugfix: clone git@host:org/repo repos with public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ in a location for all of your git projects based on the host.
 * You don't need to change to the directory where your github repos are located.
 * The base git repo will be based on the host, so they all are on the same place.
 
-```
-$ tree -L 4 ~/dev/
+```shell
+cloner git --repo https://github.com/comsysto/redis-locks-with-grafana
+cloner git --repo git@github.com:marcellodesales/alpine-git-hub-docker-image.git
+cloner git --repo https://github.com/intuit/intuit-spring-cloud-config-inspector
+cloner git --repo git@github.com:intuit/unmazedboot
+cloner git --repo https://gitlab.com:supercash/services/sms-gateway-service.git
+
+tree -L 4 ~/dev/
 /Users/marcellodesales/dev/
 ├── github.com
 │   ├── comsysto
@@ -18,16 +24,15 @@ $ tree -L 4 ~/dev/
 │       └── alpine-git-hub-docker-image
 │   ├── intuit
 │   │   ├── intuit-spring-cloud-config-inspector
-│   │   ├── intuit-spring-cloud-config-validator
 │   │   └── unmazedboot
-├── github.google.com
-│   ├── docker
-│   ├── kubernetes
 ├── gitlab.com
 │   └── supercash
 │       └── services
 │           └── sms-gateway-service
 ```
+
+> **ATTENTION**: Assuming all defaults, of the clone location to `~/dev`, the cloned
+> and the private key being `~/.ssh/id_rsa`. See below the options to the CLI.
 
 # Config
 
@@ -44,22 +49,44 @@ When the CLI runs, it will create the dirs `git.cloneBaseDir/git.host/git.org/gi
 
 > NOTE: Gitlab's and other hosts may be located in deeper folders.
 
+# Options
+
+* Just run the help to see the current options
+
+```
+cloner git --help
+Clones a given git repo URL
+
+Usage:
+  cloner git [flags]
+
+Flags:
+  -f, --force               Forces cloning by deleting existing dir
+  -h, --help                help for git
+  -k, --privateKey string   The private key associated to the public key to clone 'git@' repos
+  -r, --repo string         The repo URL to clone
+
+Global Flags:
+      --cloner string      Config file (default is $HOME/.cloner.yaml) (default "cloner")
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
 # Running
 
 ```go
-$ cloner git --repo https://github.com/comsysto/redis-locks-with-grafana
+cloner git --repo https://github.com/comsysto/redis-locks-with-grafana
 INFO[0000] Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'
 INFO[2020-09-08T12:28:11-03:00] Cloning into '/Users/marcellodesales/dev/github.com/comsysto/redis-locks-with-grafana'
 Enumerating objects: 233, done.
 Total 233 (delta 0), reused 0 (delta 0), pack-reused 233
 INFO[2020-09-08T12:28:18-03:00] Done...
 
-$ cloner git --repo https://github.com/comsysto/redis-locks-with-grafana
+cloner git --repo https://github.com/comsysto/redis-locks-with-grafana
 INFO[0000] Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'
 ERRO[2020-09-08T12:29:58-03:00] Can't clone repo: clone location '/Users/marcellodesales/dev/github.com/comsysto/redis-locks-with-grafana' exists and it's not empty
 ERRO[2020-09-08T12:29:58-03:00] You can specify --force or -f to delete the existing dir and clone again. Make sure there are no panding changes!
 
-$ cloner git --repo https://github.com/comsysto/redis-locks-with-grafana -f
+cloner git --repo https://github.com/comsysto/redis-locks-with-grafana -f
 INFO[0000] Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'
 INFO[2020-09-08T12:30:42-03:00] Forcing clone...
 INFO[2020-09-08T12:30:42-03:00] Deleted dir '/Users/marcellodesales/dev/github.com/comsysto/redis-locks-with-grafana'

--- a/api/git/git_service.go
+++ b/api/git/git_service.go
@@ -16,7 +16,6 @@ limitations under the License.
 package git
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -24,8 +23,12 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/marcellodesales/cloner/config"
 	"github.com/marcellodesales/cloner/util"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type GitServiceType struct{}
@@ -36,24 +39,37 @@ var GitService GitServiceType
 var githubRepoUrlRe = regexp.MustCompile(`(?m)^(?P<protocol>https|git)(:\/\/|@)(?P<host>[^\/:]+)[\/:](?P<user>[^\/:]+)\/(?P<repo>.+).git$`)
 
 // Init from the CLI inputs
-func (service GitServiceType) Init(repoUrl string, forceClone bool) *CloneGitRepoRequest {
-	return &CloneGitRepoRequest{
-		Url:   repoUrl,
-		Force: forceClone,
+func (service GitServiceType) Init(repoUrl, privateKeyPath string, forceClone bool) (*CloneGitRepoRequest, error) {
+	if repoUrl == "" {
+		return nil, fmt.Errorf("you must provide the repo URL")
 	}
+
+	if !strings.HasSuffix(repoUrl, ".git") {
+		repoUrl += ".git"
+	}
+
+	// Make a clone repo request based on the input from the CLI
+	if strings.HasPrefix(repoUrl, "git@") && privateKeyPath == "" {
+		privateKeyPath = fmt.Sprintf("%s/.ssh/id_rsa", os.Getenv("HOME"))
+		log.Debugf("Assuming default private key at '%s': repo URL is prefixed by 'git@'", privateKeyPath)
+	}
+
+	// for git@host:org/repo, SSH keys are used as auth form.
+	if privateKeyPath != "" && !util.FileExists(privateKeyPath) {
+		return nil, fmt.Errorf("private key '%s' does NOT exist. Make sure to provide for ssh-related clones (git@) repos", privateKeyPath)
+	}
+
+	return &CloneGitRepoRequest{
+		Url:            repoUrl,
+		Force:          forceClone,
+		PrivateKeyFile: privateKeyPath,
+	}, nil
 }
 
 /**
  * @return a new instance of the GitRepoType
  */
 func (service GitServiceType) ParseRepoString(gitRepoClone *CloneGitRepoRequest) error {
-	if gitRepoClone.Url == "" {
-		return errors.New("you must provide the repo URL")
-	}
-
-	if !strings.HasSuffix(gitRepoClone.Url, ".git") {
-		gitRepoClone.Url += ".git"
-	}
 	// Parse the regex
 	gitRepoValues, err := util.RegexProcessString(githubRepoUrlRe, gitRepoClone.Url)
 	if err != nil {
@@ -137,13 +153,26 @@ func (service GitServiceType) MakeCloneDir(gitRepoClone *CloneGitRepoRequest, co
  * Clone the git repo to the clone location using go-git
  */
 func (service GitServiceType) GoCloneRepo(gitRepoClone *CloneGitRepoRequest, config *config.Configuration) error {
-	//gitRepoClone.CloneLocation = service.GetRepoLocalPath(gitRepoClone, config)
+	var publicKeys *ssh.PublicKeys
+	var err error
+	if strings.HasPrefix(gitRepoClone.Url, "git@") {
+		// default private key is
+		privateKeyFile := fmt.Sprintf("%s/.ssh/gmail_rsa", os.Getenv("HOME"))
+		publicKeys, err = ssh.NewPublicKeysFromFile("git", privateKeyFile, "")
+		if err != nil {
+			return err
+		}
+		log.Debugf("Using public keys %s", publicKeys.String())
+	}
 
 	// https://git-scm.com/book/en/v2/Appendix-B%3A-Embedding-Git-in-your-Applications-go-git
-	_, err := git.PlainClone(gitRepoClone.CloneLocation, false, &git.CloneOptions{
+	log.Debugf("Attempting to clone repo '%s' => '%s'", gitRepoClone.Url, gitRepoClone.CloneLocation)
+	_, err = git.PlainClone(gitRepoClone.CloneLocation, false, &git.CloneOptions{
 		URL:      gitRepoClone.Url,
+		Auth:     publicKeys,
 		Progress: os.Stdout,
 	})
+
 	return err
 }
 

--- a/api/git/git_type.go
+++ b/api/git/git_type.go
@@ -34,8 +34,9 @@ type CloneGitRepoRequest struct {
 	//Revision string
 	Depth uint
 	//SparsePaths []string
-	CloneLocation string
-	Force         bool
+	CloneLocation  string
+	Force          bool
+	PrivateKeyFile string
 }
 
 func (gitRepo GitRepoType) GetRepoDir() string {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/marcellodesales/cloner/api/git"
@@ -37,8 +38,9 @@ var initCmd = &cobra.Command{
 func GitCloneCmd(cmd *cobra.Command, args []string) {
 	repo, _ := cmd.Flags().GetString("repo")
 	forceClone, _ := cmd.Flags().GetBool("force")
+	privateKey, _ := cmd.Flags().GetString("privateKey")
 
-	exitCode, errors := executeGitClone(repo, forceClone)
+	exitCode, errors := executeGitClone(repo, privateKey, forceClone)
 
 	// Show any errors if any
 	if len(errors) > 0 {
@@ -51,9 +53,11 @@ func GitCloneCmd(cmd *cobra.Command, args []string) {
 	os.Exit(exitCode)
 }
 
-func executeGitClone(repo string, forceClone bool) (int, []error) {
-	// Make a clone repo request based on the input from the CLI
-	cloneRepoRequest := git.GitService.Init(repo, forceClone)
+func executeGitClone(repo, privateKeyPath string, forceClone bool) (int, []error) {
+	cloneRepoRequest, err := git.GitService.Init(repo, privateKeyPath, forceClone)
+	if err != nil {
+		return -1, []error{fmt.Errorf("can't initialize due to parameters' values: %v", err)}
+	}
 
 	// Execute the implementation, getting the exit code and any error
 	return git.CloneGitRepo(cloneRepoRequest, config.INSTANCE)
@@ -71,6 +75,7 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	initCmd.Flags().StringP("repo", "r", "", "The repo URL to clone")
+	initCmd.Flags().StringP("privateKey", "k", "", "The private key associated to the public key to clone 'git@' repos")
 
 	var verbose = false
 	// https://github.com/spf13/cobra/issues/818#issuecomment-489021216

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -47,9 +47,16 @@ func TestGitCloneWithWrongURLs(t *testing.T) {
 func TestGitCloneSuccessfullyForcing(t *testing.T) {
 	existingDirTests := []CliTests{
 		{
-			title: "Given existing cloned repo",
+			title: "Given existing https://host/org/repo repo URL to clone",
 			input: TestInput{
 				url:        "https://github.com/comsysto/redis-locks-with-grafana",
+				forceClone: true},
+			exitCode: 0,
+		},
+		{
+			title: "Given existing 'git@host:org/repo' cloned repo",
+			input: TestInput{
+				url:        "git@github.com:marcellodesales/docker-git-backup-to-s3.git",
 				forceClone: true},
 			exitCode: 0,
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -50,8 +50,9 @@ func setup() {
 
 // the current CLI input to be tested
 type TestInput struct {
-	url        string
-	forceClone bool
+	url            string
+	forceClone     bool
+	privateKeyPath string
 }
 
 type CliTests struct {
@@ -73,7 +74,7 @@ func ExecuteCliTestsStrategy(t *testing.T, cliTests []CliTests) {
 			Convey(tst.title, t, func() {
 
 				// Actual clone command to be tested
-				exitCode, errors := executeGitClone(tst.input.url, tst.input.forceClone)
+				exitCode, errors := executeGitClone(tst.input.url, tst.input.privateKeyPath, tst.input.forceClone)
 
 				Convey(fmt.Sprintf("The exit code should be %d", tst.exitCode), func() {
 					So(exitCode, ShouldEqual, tst.exitCode)


### PR DESCRIPTION
# Errors for cloning

* Replace the git Docker handler in #6 made the CLI not know how to clone SSH-based URLs.  
* The result is described on #14

```shell
$ ./dist/cloner-darwin-local git --repo git@github.com:marcellodesales/unmazedboot.git -f
INFO[0000] Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'
INFO[2020-09-17T07:50:03-03:00] Forcing clone...
INFO[2020-09-17T07:50:03-03:00] Deleted dir '/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot'
INFO[2020-09-17T07:50:03-03:00] Cloning into '/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot'
ERRO[2020-09-17T07:50:12-03:00] can't clone the repo at 'github.com/marcellodesales/unmazedboot': 
      dial tcp: lookup github.com on 192.168.1.1:53: no such host
```

# SSH Auth Support

* Adding the `privateKey` support for `git@host:org/repo` URLs verified by the prefix `git@`
  * Adding the default private key from `~/.ssh/id_rsa`
* The actual `Public Key` is the one used by `Go-git` handler to connect with the servers whose URLs are prefixed by `git@`

```shell
$ ./dist/cloner-darwin-local -v debug git --repo git@github.com:marcellodesales/unmazedboot.git -f
INFO[0000] Loading the config object 'git' from '/Users/marcellodesales/.cloner.yaml'
DEBU[2020-09-17T15:22:47-03:00] Assuming default private key at '/Users/marcellodesales/.ssh/id_rsa': repo URL is prefixed by 'git@'
DEBU[2020-09-17T15:22:47-03:00] config.git.cloneBaseDir=/Users/marcellodesales/dev
INFO[2020-09-17T15:22:47-03:00] Forcing clone...
INFO[2020-09-17T15:22:47-03:00] Deleted dir '/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot'
INFO[2020-09-17T15:22:47-03:00] Cloning into '/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot'
DEBU[2020-09-17T15:22:47-03:00] Attempting to clone repo 'git@github.com:marcellodesales/unmazedboot.git' => '/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot'
DEBU[2020-09-17T15:22:47-03:00] Using public keys user: git, name: ssh-public-keys
Enumerating objects: 16, done.
Counting objects: 100% (16/16), done.
Compressing objects: 100% (16/16), done.
Total 144 (delta 9), reused 2 (delta 0), pack-reused 128
INFO[2020-09-17T15:22:53-03:00] Done...
INFO[2020-09-17T15:22:53-03:00]
/Users/marcellodesales/dev/github.com/marcellodesales/unmazedboot
└── .env
└── CHANGELOG
└── LICENSE
└── README.md
```