### PR TITLE
:hammer: Makefile: docker-push-master pushes current image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,10 @@ ifndef GITHUB_ACTION
 endif
 	$(eval BUILD_IMAGE_TAG=$(shell BIN_VERSION=$(BIN_VERSION) docker-compose config | grep image | awk '{print $$2}'))
 	$(eval DEV_IMAGE_NAME=$(shell echo $(BUILD_IMAGE_TAG) | awk -F ':' '{print $$1}'))
+	$(eval VERSION_TAG=$(shell echo $(BUILD_IMAGE_TAG) | sed 's/[:-]/\/cli:/g'))
 	$(eval LATEST_IMAGE_TAG=docker.pkg.github.com/$(DEV_IMAGE_NAME)/cli:latest)
+	docker tag $(BUILD_IMAGE_TAG) $(VERSION_TAG)
+	docker push $(VERSION_TAG)
 	docker tag $(BUILD_IMAGE_TAG) $(LATEST_IMAGE_TAG)
 	docker push $(LATEST_IMAGE_TAG)
 


### PR DESCRIPTION
The tag is also supposed to be pushed so that users can run the
docker container for the specific image version.

https://github.com/marcellodesales/cloner/packages/403407